### PR TITLE
Add core prompt files for Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+# Copilot Custom Instructions
+
+## TypeScript Best Practices
+Always generate strongly typed TypeScript code, following `strict: true`.
+
+## Next.js API Standards
+Use Next.js **server actions** instead of legacy `api/` routes.
+
+## React Components
+- Always use **functional components** & hooks.
+- Follow **Tailwind CSS** for styling.
+- Avoid inline styles.
+
+## Security Practices
+- Validate API input using **Zod** or **Yup**.
+- Enforce **JWT authentication**.
+- Use **parameterized queries** to prevent SQL Injection.

--- a/.github/prompts/kde-wayland-scripting.prompt.md
+++ b/.github/prompts/kde-wayland-scripting.prompt.md
@@ -1,0 +1,17 @@
+# KDE Wayland Scripting Guidelines
+
+## Guidelines:
+- **DO NOT use X11 dependencies**—only **Wayland-compatible** scripts.
+- Prefer **KWin scripting API** for managing windows.
+- Use **Plasma Shell widgets** for automation.
+- Avoid modifying core KDE components—use **extensions instead**.
+
+## Example:
+```js
+const ws = workspace;
+ws.clientList().forEach(client => {
+  if (client.windowClass === "firefox") {
+    client.minimized = true;
+  }
+});
+```

--- a/.github/prompts/nextjs-api-standards.prompt.md
+++ b/.github/prompts/nextjs-api-standards.prompt.md
@@ -1,0 +1,20 @@
+# Next.js API Standards (v15+)
+
+## Guidelines:
+- **Use Next.js server actions**—DO NOT use legacy `pages/api/` routes.
+- Validate API input with **Zod** or **Yup**.
+- API responses **must return JSON** and **never expose raw errors**.
+- Use **Edge Functions** when possible for performance.
+
+## Example:
+```ts
+"use server";
+import { z } from "zod";
+
+const schema = z.object({ email: z.string().email() });
+
+export async function registerUser(data: unknown) {
+  const parsed = schema.parse(data);
+  return { message: `User ${parsed.email} registered!` };
+}
+```

--- a/.github/prompts/puppeteer-usage-guidelines.prompt.md
+++ b/.github/prompts/puppeteer-usage-guidelines.prompt.md
@@ -1,0 +1,25 @@
+# Puppeteer Usage Guidelines
+
+## Guidelines:
+- **Reuse browser instances**—DO NOT launch multiple instances per request.
+- Always **close pages after usage** to prevent memory leaks.
+- Use **`page.waitForSelector()`** before interacting with elements.
+- Prefer **headless mode** unless debugging.
+
+## Example:
+```ts
+const puppeteer = require("puppeteer");
+
+async function scrapeData() {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  await page.goto("https://example.com");
+  const title = await page.title();
+
+  await page.close();
+  await browser.close();
+
+  return title;
+}
+```

--- a/.github/prompts/react-component-guidelines.prompt.md
+++ b/.github/prompts/react-component-guidelines.prompt.md
@@ -1,0 +1,20 @@
+# React Component Guidelines
+
+## Guidelines:
+- **Use functional components & hooks** (NO class components).
+- Use **Tailwind CSS** for styling.
+- Props should be **typed explicitly**.
+- Avoid inline styles—use Tailwind classes or `styled-components`.
+- Always destructure props.
+
+## Example:
+```tsx
+interface ButtonProps {
+  text: string;
+  onClick: () => void;
+}
+
+export function Button({ text, onClick }: ButtonProps) {
+  return <button onClick={onClick} className="bg-blue-500 text-white">{text}</button>;
+}
+```

--- a/.github/prompts/testing-strategies.prompt.md
+++ b/.github/prompts/testing-strategies.prompt.md
@@ -1,0 +1,18 @@
+# Testing Strategies
+
+## Guidelines:
+- All new functions **must have Jest or Vitest tests**.
+- **Use `describe` & `it` blocks** for structuring tests.
+- Prefer **mocking API calls** instead of real network requests.
+- Ensure **at least 80% test coverage** for critical modules.
+
+## Example:
+```ts
+import { sum } from "./math";
+
+describe("sum function", () => {
+  it("adds two numbers correctly", () => {
+    expect(sum(2, 3)).toBe(5);
+  });
+});
+```

--- a/.github/prompts/typescript-best-practices.prompt.md
+++ b/.github/prompts/typescript-best-practices.prompt.md
@@ -1,0 +1,19 @@
+# TypeScript Best Practices
+
+## Guidelines:
+- Always use **`strict: true`** in TypeScript configurations.
+- Prefer **const** over **let** unless reassignment is necessary.
+- Use **ESM (ECMAScript Modules)**—avoid CommonJS (`require()`).
+- When defining objects, **prefer interfaces over types**.
+- Enforce **proper error handling**—avoid empty `catch` blocks.
+- Use **generics** for reusable functions & classes.
+
+## Example:
+```ts
+interface User {
+  id: number;
+  name: string;
+}
+
+const fetchUser = async (id: number): Promise<User> => { ... }
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate-prompts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Validate prompt files
+        run: npm run validate-prompts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Check for changes in prompt files before committing
+git diff --cached --name-only | grep -E '\.github/prompts/.*\.prompt\.md$' | while read -r file; do
+  # Ensure prompt files follow a specific format or guidelines
+  if ! grep -qE '^# ' "$file"; then
+    echo "Error: $file does not follow the required format."
+    exit 1
+  fi
+done

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Project B
+
+## Purpose of the `.github/prompts/` Directory
+
+The `.github/prompts/` directory contains prompt files that define best practices and guidelines for various aspects of the project. These prompt files are used to ensure consistent and high-quality code generation by GitHub Copilot.
+
+### Core Prompt Files
+
+The following core prompt files are included in the `.github/prompts/` directory:
+
+- `typescript-best-practices.prompt.md`
+- `nextjs-api-standards.prompt.md`
+- `react-component-guidelines.prompt.md`
+- `testing-strategies.prompt.md`
+- `puppeteer-usage-guidelines.prompt.md`
+- `kde-wayland-scripting.prompt.md`
+
+### How to Use Prompt Files
+
+#### Attaching a Prompt in Copilot Chat
+
+1. Open **Copilot Chat** (**`⌃⌘I`** or **`Ctrl+Alt+I`**).
+2. Click **Attach Context** (📎).
+3. Select **Prompt...** → Choose one of the **`.prompt.md`** files.
+4. Enter your request.
+
+**Example**:
+```
+@workspace /fix testing
+📎 Attached: testing-strategies.prompt.md
+```
+Copilot will now fix your tests according to **your testing rules**.
+
+#### Using Prompt Files in Copilot Edits
+
+For **multi-file editing**:
+
+1. Open **Copilot Edits** (**`⇧⌘I`** or **`Ctrl+Shift+I`**).
+2. Click **Add Files...** → Select the files Copilot should edit.
+3. Attach the relevant **`.prompt.md`** files.
+4. Describe the edit → Copilot follows the **rules inside the prompt file**.
+
+**Example**:
+```
+📎 Attached: nextjs-api-standards.prompt.md
+📎 Attached: error-handling-and-logging.prompt.md
+```
+Copilot will now **refactor API endpoints & apply structured error handling**.
+
+### Automating Prompt File Usage
+
+Instead of manually attaching prompts every time, you can **auto-apply them** in **`.github/copilot-instructions.md`**.
+
+#### `.github/copilot-instructions.md`
+
+```md
+# Copilot Custom Instructions
+
+## TypeScript Best Practices
+Always generate strongly typed TypeScript code, following `strict: true`.
+
+## Next.js API Standards
+Use Next.js **server actions** instead of legacy `api/` routes.
+
+## React Components
+- Always use **functional components** & hooks.
+- Follow **Tailwind CSS** for styling.
+- Avoid inline styles.
+
+## Security Practices
+- Validate API input using **Zod** or **Yup**.
+- Enforce **JWT authentication**.
+- Use **parameterized queries** to prevent SQL Injection.
+```
+Copilot will now follow these rules automatically.

--- a/scripts/update-prompts.js
+++ b/scripts/update-prompts.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const promptsDir = path.join(__dirname, '../.github/prompts');
+
+const promptFiles = [
+  'typescript-best-practices.prompt.md',
+  'nextjs-api-standards.prompt.md',
+  'react-component-guidelines.prompt.md',
+  'testing-strategies.prompt.md',
+  'puppeteer-usage-guidelines.prompt.md',
+  'kde-wayland-scripting.prompt.md'
+];
+
+function updatePromptFiles() {
+  promptFiles.forEach(file => {
+    const filePath = path.join(promptsDir, file);
+    if (fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const updatedContent = content.replace(/<!--.*?-->/gs, ''); // Remove HTML comments
+      fs.writeFileSync(filePath, updatedContent, 'utf-8');
+      console.log(`Updated: ${file}`);
+    } else {
+      console.log(`File not found: ${file}`);
+    }
+  });
+}
+
+updatePromptFiles();


### PR DESCRIPTION
Add six core prompt files to the `.github/prompts/` directory to define best practices and guidelines for various aspects of the project.

* **Prompt Files**:
  - Add `typescript-best-practices.prompt.md` with TypeScript best practices.
  - Add `nextjs-api-standards.prompt.md` with Next.js API standards.
  - Add `react-component-guidelines.prompt.md` with React component guidelines.
  - Add `testing-strategies.prompt.md` with testing strategies.
  - Add `puppeteer-usage-guidelines.prompt.md` with Puppeteer usage guidelines.
  - Add `kde-wayland-scripting.prompt.md` with KDE Wayland scripting guidelines.

* **Documentation**:
  - Add a section in `README.md` explaining the purpose of the `.github/prompts/` directory and how to use the prompt files.

* **Automation**:
  - Add `.github/copilot-instructions.md` with custom instructions for Copilot to follow best practices.
  - Add `.github/workflows/ci.yml` to validate prompt files during the build process.
  - Add `scripts/update-prompts.js` to manage and update prompt files.
  - Add `.husky/pre-commit` hook to check for changes in prompt files before committing.

